### PR TITLE
Update README.md (Fix #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SudachiPy requires Python3.5+.
 SudachiPy is not registered to PyPI just yet, so you may not install it via `pip` command at the moment.
 
 ```
-$ pip install git+git://github.com/WorksApplications/SudachiPy
+$ pip install -e git+git://github.com/WorksApplications/SudachiPy@develop#egg=SudachiPy
 ```
 The dictionary file is not included in the repository. You can get the built dictionary from [Releases · WorksApplications/Sudachi](https://github.com/WorksApplications/Sudachi/releases). Please download either `sudachi-x.y.z-dictionary-core.zip` or `sudachi-x.y.z-dictionary-full.zip`, unzip and rename it to `system.dic`, then place it under `SudachiPy/resources/`. In the end, we would like to make a flow to get these resources via the code, like [NLTK](https://www.nltk.org/data.html) (e.g., `import nltk; nltk.download()`) or [spaCy](https://spacy.io/usage/models) (e.g., `$python -m spacy download en`).
 


### PR DESCRIPTION
As SudachiPy currently under development it should be installed in development mode.

Not mentioning the flag (-e) during installation will raise error.