### PR TITLE
Fix the bug related to default inhibited connection refs #17

### DIFF
--- a/sudachipy/dictionarylib/grammar.py
+++ b/sudachipy/dictionarylib/grammar.py
@@ -1,5 +1,5 @@
 class Grammar:
-    INHIBITED_CONNECTION = float("inf")
+    INHIBITED_CONNECTION = 0x7fff
 
     def __init__(self, bytes_, offset):
         self.POS_DEPTH = 6

--- a/sudachipy/dictionarylib/grammar.py
+++ b/sudachipy/dictionarylib/grammar.py
@@ -1,5 +1,5 @@
 class Grammar:
-    INHIBITED_CONNECTION = 0x7F
+    INHIBITED_CONNECTION = float("inf")
 
     def __init__(self, bytes_, offset):
         self.POS_DEPTH = 6


### PR DESCRIPTION
Fix errors when the connection cost is equal to 127.
In current Java ver, `Short.MAX_VALUE` has been set as default. 

Before
```
> echo "姚莉によって" | sudachipy
Traceback (most recent call last):
  File "/home/manabeh/.pyenv/versions/anaconda3-4.4.0/bin/sudachipy", line 11, in <module>
    load_entry_point('SudachiPy', 'console_scripts', 'sudachipy')()
  File "/home/manabeh/workspace/sudachi-dep/for_dep/SudachiPy/sudachipy/command_line.py", line 66, in main
    run(tokenizer_obj, mode, input, output, print_all)
  File "/home/manabeh/workspace/sudachi-dep/for_dep/SudachiPy/sudachipy/command_line.py", line 14, in run
    for m in tokenizer.tokenize(mode, line):
  File "/home/manabeh/workspace/sudachi-dep/for_dep/SudachiPy/sudachipy/tokenizer.py", line 63, in tokenize
    path = self.lattice.get_best_path()
  File "/home/manabeh/workspace/sudachi-dep/for_dep/SudachiPy/sudachipy/lattice.py", line 86, in get_best_path
    raise AttributeError("EOS is not connected to BOS")
AttributeError: EOS is not connected to BOS
```

After
```
> echo "姚莉によって" | sudachipy
姚      名詞,固有名詞,人名,姓,*,*       姚
莉      名詞,固有名詞,人名,一般,*,*     莉
に      助詞,格助詞,*,*,*,*     に
よっ    動詞,一般,*,*,五段-ラ行,連用形-促音便   よる
て      助詞,接続助詞,*,*,*,*   て
EOS
```