### PR TITLE
Put default dictionary in Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,16 +1,14 @@
 * text=auto
-
 *.def text
 *.in text
 *.json text
 *.md text
 *.py text
 *.txt text
-
 *.pyc binary
 *.pyd binary
 *.pyo binary
 *.pyw binary
-*.dic binary
+*.dic filter=lfs diff=lfs merge=lfs -text
 *.png binary
 *.jpg binary

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,3 @@ ENV/
 # IDE, Editor
 .idea/
 .vscode/
-
-# Sudachi dictionary
-*.dic

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sudachi & SudachiPy are developed in [WAP Tokushima Laboratory of AI and NLP](ht
 
 ## Setup
 
-SudachiPy requires Python3.5+.
+SudachiPy requires Python3.5+ and [Git-LFS](https://git-lfs.github.com/).
 
 As SudachiPy is currently under development, it is not registered to PyPI just yet. You may install the package using following `pip` command at the moment.
 
@@ -27,9 +27,11 @@ $ pip install -e .
 
 ### Dictionary
 
-The dictionary file stored in Git LFS is not the full dictionary. For full dictionary or other dictionary models please see [Releases · WorksApplications/Sudachi](https://github.com/WorksApplications/Sudachi/releases).
+SudachiPy needs Git LFS to download default dictionary. If you fail to build the dictionaries, install Git LFS and execute `git lfs pull` on `<repodir>`<sup>^</sup>.
 
-Currently, dictionary **must** be located on `<repodir>/resources/system.dic`. When you are changing the model, you may do as per following example. Following example will download, unpack, delete current dictionary if any, and finally rename the newly downloaded dictionary.
+The default dictionary is stored on Git LFS and is not full dictionary. For full dictionary or other dictionary models please see [Releases · WorksApplications/Sudachi](https://github.com/WorksApplications/Sudachi/releases).
+
+Currently, dictionary **must** be located on `<repodir>/resources/system.dic`<sup>^</sup>. When you are changing the model, you may do as per following example. Following example will download, unpack, delete current dictionary if any, and finally rename the newly downloaded dictionary.
 
 ```bash
 $ cd resources
@@ -38,7 +40,7 @@ $ ls | grep -e "^system.dic$" | xargs rm -f
 $ mv system_core.dic system.dic
 ```
 
-**Note**: if you use virtual environment and pip installation from git, `<repodir>` is `<virtual_env_dir>/src/sudachipy`
+**<sup>^</sup>Note**: if you use virtual environment and pip installation from git, `<repodir>` is `<virtual_env_dir>/src/sudachipy`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,38 @@ Sudachi & SudachiPy are developed in [WAP Tokushima Laboratory of AI and NLP](ht
 
 SudachiPy requires Python3.5+.
 
-SudachiPy is not registered to PyPI just yet, so you may not install it via `pip` command at the moment.
+As SudachiPy is currently under development, it is not registered to PyPI just yet. You may install the package using following `pip` command at the moment.
 
 ```
 $ pip install -e git+git://github.com/WorksApplications/SudachiPy@develop#egg=SudachiPy
 ```
-The dictionary file is not included in the repository. You can get the built dictionary from [Releases · WorksApplications/Sudachi](https://github.com/WorksApplications/Sudachi/releases). Please download either `sudachi-x.y.z-dictionary-core.zip` or `sudachi-x.y.z-dictionary-full.zip`, unzip and rename it to `system.dic`, then place it under `SudachiPy/resources/`. In the end, we would like to make a flow to get these resources via the code, like [NLTK](https://www.nltk.org/data.html) (e.g., `import nltk; nltk.download()`) or [spaCy](https://spacy.io/usage/models) (e.g., `$python -m spacy download en`).
+
+or, you can clone and install as per following example.
+
+```bash
+$ git clone https://github.com/WorksApplications/SudachiPy.git
+$ cd SudachiPy
+$ pip install -e .
+```
+
+### Dictionary
+
+The dictionary file stored in Git LFS is not the full dictionary. For full dictionary or other dictionary models please see [Releases · WorksApplications/Sudachi](https://github.com/WorksApplications/Sudachi/releases).
+
+Currently, dictionary **must** be located on `<repodir>/resources/system.dic`. When you are changing the model, you may do as per following example. Following example will download, unpack, delete current dictionary if any, and finally rename the newly downloaded dictionary.
+
+```bash
+$ cd resources
+$ wget https://github.com/WorksApplications/Sudachi/releases/download/v0.1.0/sudachi-0.1.0-dictionary-core.zip && unzip sudachi-0.1.0-dictionary-core.zip
+$ ls | grep -e "^system.dic$" | xargs rm -f
+$ mv system_core.dic system.dic
+```
+
+**Note**: if you use virtual environment and pip installation from git, `<repodir>` is `<virtual_env_dir>/src/sudachipy`
 
 ## Usage
 
-### As a command
+### Command Line Interface
 
 After installing SudachiPy, you may also use it in the terminal via command `sudachipy`.
 
@@ -44,7 +66,7 @@ optional arguments:
 
 ```
 
-### As a Python package
+### Python Package
 
 Here is an example usage;
 

--- a/resources/system.dic
+++ b/resources/system.dic
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6591ff70e215c2de604039f4da26bc582319cfe58cc615676a1e477ee6a2c55d
+size 200992799


### PR DESCRIPTION
Enable user / tester to run directly with 1-line setup, e.g. `pip install -e`.