### PR TITLE
Introduce flake8 as formatting tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,10 @@ tokenizer_obj.tokenize(mode, "SUMMER")[0].normalized_form()
 tokenizer_obj.tokenize(mode, "シュミレーション")[0].normalized_form()
 # => 'シミュレーション'
 ```
+
+## For developer
+
+### Code format
+
+You have to run `./scripts/format.sh` and check if your code is in rule before PR.
+This code formatting script will be integrated to CI system later. `flake8` is required.

--- a/scripts/flake8.cfg
+++ b/scripts/flake8.cfg
@@ -1,0 +1,13 @@
+[flake8]
+ignore = \
+	F632, \ # use ==/!= to compare str, bytes, and int literals
+	F401, \ # imported but unused
+	C901, \ # too complex
+	E226, \ # missing whitespace around arithmetic operator
+	E201, \ # whitespace after '('
+	E202, \ # whitespace before ')'
+	E501, \ # line too long (141 > 140 characters)
+
+max-line-length = 140
+exclude = tests/*, __init.py__
+max-complexity = 10

--- a/scripts/flake8.cfg
+++ b/scripts/flake8.cfg
@@ -7,7 +7,11 @@ ignore = \
 	E201, \ # whitespace after '('
 	E202, \ # whitespace before ')'
 	E501, \ # line too long (141 > 140 characters)
-
+	E741, \ # ambiguous variable name
+	W605, \ # invalid escape sequence
+	F811, \ # redefinition of unused ...
+	W504, \ # line break after binary operator
+	F823, \ # local variable '...' defined in enclosing scope on line ... referenced before assignment
 max-line-length = 140
-exclude = tests/*, __init.py__
+exclude = __init.py__
 max-complexity = 10

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+cd $(dirname $0)
+flake8 --show --config=flake8.cfg ../sudachipy
+flake8 --show --config=flake8.cfg ../tests
+

--- a/sudachipy/command_line.py
+++ b/sudachipy/command_line.py
@@ -62,8 +62,8 @@ def main():
     if is_enable_dump:
         tokenizer_obj.set_dump_output(output)
 
-    input = fileinput.input(args.input_files, openhook=fileinput.hook_encoded("utf-8"))
-    run(tokenizer_obj, mode, input, output, print_all)
+    input_ = fileinput.input(args.input_files, openhook=fileinput.hook_encoded("utf-8"))
+    run(tokenizer_obj, mode, input_, output, print_all)
 
     output.close()
 

--- a/sudachipy/dartsclone/bitvector.py
+++ b/sudachipy/dartsclone/bitvector.py
@@ -18,10 +18,10 @@ class BitVector(object):
     def set(self, id, bit):
         if bit:
             self.units[int(id / self.UNIT_SIZE)] \
-                    = self.units[int(id / self.UNIT_SIZE)] | 1 << (id % self.UNIT_SIZE)
+                = self.units[int(id / self.UNIT_SIZE)] | 1 << (id % self.UNIT_SIZE)
         else:
             self.units[int(id / self.UNIT_SIZE)] \
-                    = self.units[int(id / self.UNIT_SIZE)] & ~(1 << (id % self.UNIT_SIZE))
+                = self.units[int(id / self.UNIT_SIZE)] & ~(1 << (id % self.UNIT_SIZE))
 
     def is_empty(self):
         return len(self.units) is 0
@@ -55,4 +55,3 @@ class BitVector(object):
         unit += unit >> 8
         unit += unit >> 16
         return unit & 0xFF
-

--- a/sudachipy/dartsclone/dawgbuilder.py
+++ b/sudachipy/dartsclone/dawgbuilder.py
@@ -32,8 +32,8 @@ class DAWGBuilder(object):
 
         def __str__(self):
             return "child: %d, sibling: %d, label: %c, is_state: %d, has_sibling: %d" % (
-                    self.child, self.sibling, self.label, int(self.is_state), int(self.has_sibling)
-                    )
+                self.child, self.sibling, self.label, int(self.is_state), int(self.has_sibling)
+            )
 
     class Unit(object):
         def __init__(self):

--- a/sudachipy/dictionary.py
+++ b/sudachipy/dictionary.py
@@ -8,17 +8,12 @@ from . import plugin
 
 
 class Dictionary:
-    def __init__(self, settings, path=None):
+    def __init__(self, settings):
         self.grammar = None
         self.lexicon = None
         self.input_text_plugins = []
         self.oov_provider_plugins = []
         self.path_rewrite_plugins = []
-        self.buffers = []
-
-        if path is None:
-            pass
-
         self.buffers = []
 
         self.read_system_dictionary(os.path.join(config.RESOURCEDIR, settings["systemDict"]))

--- a/sudachipy/dictionarylib/categorytype.py
+++ b/sudachipy/dictionarylib/categorytype.py
@@ -22,8 +22,8 @@ class CategoryType(Enum):
     def get_id(self):
         return self.id
 
-    def get_type(self, id):
+    def get_type(self, id_):
         for type_ in CategoryType.values():
-            if type_.get_id() is id:
+            if type_.get_id() is id_:
                 return type_
         return None

--- a/sudachipy/dictionarylib/doublearraylexicon.py
+++ b/sudachipy/dictionarylib/doublearraylexicon.py
@@ -1,4 +1,4 @@
-#import itertool
+# import itertool
 import struct
 
 from . import lexicon

--- a/sudachipy/dictionarylib/lexiconset.py
+++ b/sudachipy/dictionarylib/lexiconset.py
@@ -1,5 +1,6 @@
 from . import lexicon
 
+
 class LexiconSet(lexicon.Lexicon):
     def __init__(self, system_lexicon):
 

--- a/sudachipy/dictionarylib/wordidtable.py
+++ b/sudachipy/dictionarylib/wordidtable.py
@@ -1,5 +1,6 @@
 import struct
 
+
 class WordIdTable(object):
     def __init__(self, bytes_, offset):
         self.bytes = bytes_

--- a/sudachipy/dictionarylib/wordinfolist.py
+++ b/sudachipy/dictionarylib/wordinfolist.py
@@ -2,6 +2,7 @@ import struct
 
 from . import wordinfo
 
+
 class WordInfoList(object):
     def __init__(self, bytes_, offset, word_size):
         self.bytes = bytes_

--- a/sudachipy/lattice.py
+++ b/sudachipy/lattice.py
@@ -100,6 +100,6 @@ class Lattice:
                 index += 1
                 for l_node in self.end_lists[r_node.begin]:
                     cost = l_node.total_cost + \
-                           self.grammar.get_connect_cost(l_node.right_id, r_node.left_id)
+                        self.grammar.get_connect_cost(l_node.right_id, r_node.left_id)
                     print("{} ".format(cost), file=output, end="")
                 print(file=output)

--- a/sudachipy/plugin/oov/mecab_oov_plugin.py
+++ b/sudachipy/plugin/oov/mecab_oov_plugin.py
@@ -6,6 +6,7 @@ from sudachipy.dictionarylib import categorytype
 from sudachipy import latticenode
 from sudachipy.dictionarylib import wordinfo
 
+
 class MeCabOovPlugin:
     class CategoryInfo:
         def __init__(self):
@@ -132,4 +133,3 @@ class MeCabOovPlugin:
                 pos = cols[4:10]
                 oov.pos_id = grammar.get_part_of_speech_id(pos)
                 self.oov_list[type_].append(oov)
-

--- a/sudachipy/plugin/oov/simple_oov_plugin.py
+++ b/sudachipy/plugin/oov/simple_oov_plugin.py
@@ -1,9 +1,10 @@
 from sudachipy import latticenode
 from sudachipy.dictionarylib import wordinfo
 
+
 class SimpleOovPlugin:
     def set_up(self, grammar):
-        oov_pos_strings =[ "補助記号", "一般", "*", "*", "*", "*" ]
+        oov_pos_strings = [ "補助記号", "一般", "*", "*", "*", "*" ]
         self.left_id = 5968
         self.right_id = 5968
         self.cost = 3857

--- a/sudachipy/plugin/path_rewrite/join_katakana_oov_plugin.py
+++ b/sudachipy/plugin/path_rewrite/join_katakana_oov_plugin.py
@@ -43,9 +43,8 @@ class JoinKatakanaOovPlugin(PathRewritePlugin):
                     end += 1
                 if (end - begin) > 1:
                     self.concatenate_oov(path, begin, end, self.oov_pos_id, lattice)
-                    i = begin + 1 # skip next node, as we already know it is not a joinable katakana
+                    i = begin + 1  # skip next node, as we already know it is not a joinable katakana
             i += 1
-
 
     def is_katakana_node(self, text, node):
         return CategoryType.KATAKANA in self.get_char_category_types(text, node)

--- a/sudachipy/plugin/path_rewrite/path_rewrite_plugin.py
+++ b/sudachipy/plugin/path_rewrite/path_rewrite_plugin.py
@@ -68,4 +68,3 @@ class PathRewritePlugin:
 
     def get_char_category_types(self, text, node):
         return text.get_char_category_types(node.get_begin(), node.get_end())
-

--- a/sudachipy/tokenizer.py
+++ b/sudachipy/tokenizer.py
@@ -40,10 +40,10 @@ class Tokenizer:
             has_words = True if iterator else False
             for word_id, end in iterator:
                 n = latticenode.LatticeNode(self.lexicon,
-                                                    self.lexicon.get_left_id(word_id),
-                                                    self.lexicon.get_right_id(word_id),
-                                                    self.lexicon.get_cost(word_id),
-                                                    word_id)
+                                            self.lexicon.get_left_id(word_id),
+                                            self.lexicon.get_right_id(word_id),
+                                            self.lexicon.get_cost(word_id),
+                                            word_id)
                 self.lattice.insert(i, end, n)
 
             # OOV

--- a/tests/test_utf8inputtext.py
+++ b/tests/test_utf8inputtext.py
@@ -23,7 +23,7 @@ class TestUTF8InputText(unittest.TestCase):
 
         grammar = self.MockGrammar()
         char_category = dictionarylib.charactercategory.CharacterCategory()
-        char_category.read_character_definition( os.path.join(sudachipy.config.RESOURCEDIR, "char.def") )
+        char_category.read_character_definition(os.path.join(sudachipy.config.RESOURCEDIR, "char.def"))
         grammar.set_character_category(char_category)
 
         self.builder = sudachipy.utf8inputtextbuilder.UTF8InputTextBuilder(self.TEXT, grammar)
@@ -199,7 +199,7 @@ class TestUTF8InputText(unittest.TestCase):
 
         def get_character_category(self):
             char_category = dictionarylib.charactercategory.CharacterCategory()
-            char_category.read_character_definition( os.path.join(sudachipy.config.RESOURCEDIR, "char.def") )
+            char_category.read_character_definition(os.path.join(sudachipy.config.RESOURCEDIR, "char.def"))
             return char_category
 
         def set_character_category(self, char_category):

--- a/tests/test_utf8inputtext.py
+++ b/tests/test_utf8inputtext.py
@@ -23,7 +23,7 @@ class TestUTF8InputText(unittest.TestCase):
 
         grammar = self.MockGrammar()
         char_category = dictionarylib.charactercategory.CharacterCategory()
-        char_category.read_character_definition(os.path.join(sudachipy.config.RESOURCEDIR, "char.def"))
+        char_category.read_character_definition( os.path.join(sudachipy.config.RESOURCEDIR, "char.def") )
         grammar.set_character_category(char_category)
 
         self.builder = sudachipy.utf8inputtextbuilder.UTF8InputTextBuilder(self.TEXT, grammar)
@@ -199,7 +199,7 @@ class TestUTF8InputText(unittest.TestCase):
 
         def get_character_category(self):
             char_category = dictionarylib.charactercategory.CharacterCategory()
-            char_category.read_character_definition(os.path.join(sudachipy.config.RESOURCEDIR, "char.def"))
+            char_category.read_character_definition( os.path.join(sudachipy.config.RESOURCEDIR, "char.def") )
             return char_category
 
         def set_character_category(self, char_category):


### PR DESCRIPTION
related with #9
For continuous development, I'd think this project should have formatting rule.
This pull request is requiring you to introduce `flake8` as format tool.

Many illegal format are detected so I fixed just minor ones and others are muted by option in `flake8.cfg`.
The minor rules I fixed were E123, E126, E127, E225, E261, E265, E302, E303, W292, W391, W504.
(https://lintlyci.github.io/Flake8Rules/)

Any option is welcome like

- reject all (I hope some reason)
- reject code modification but accept the idea, introducing format tool
- accept all