### PR TITLE
build dictionary from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,26 @@ The dictionary file is not included in the repository. You can get the built dic
 After installing SudachiPy, you may also use it in the terminal via command `sudachipy`.
 
 ```
-$ sudachipy -h
-usage: sudachipy [-h] [-r file] [-m {A,B,C}] [-o file] [-a] [-d] [-v] ...
+$ sudachipy
+usage: sudachipy [-h] [-v] {tokenize,build,ubuild} ...
 
 Japanese Morphological Analyzer
+
+positional arguments:
+  {tokenize,build,ubuild}
+    tokenize            see `tokenize -h`
+    build               see `build -h`
+    ubuild              see `ubuild -h`
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --version         show program's version number and exit
+```
+```
+$ sudachipy tokenize -h
+usage: sudachipy tokenize [-h] [-r file] [-m {A,B,C}] [-o file] [-a] [-d] ...
+
+Japanese Morphological Analyze
 
 positional arguments:
   input file(s)
@@ -41,7 +57,38 @@ optional arguments:
   -o file        the output file
   -a             print all of the fields
   -d             print the debug information
-  -v, --version  show program's version number and exit
+```
+```
+$ sudachipy build -h
+usage: sudachipy build [-h] [-o file] [-d string] -m file file [file ...]
+
+Build Sudachi Dictionary
+
+positional arguments:
+  file        source files with CSV format (one of more)
+
+optional arguments:
+  -h, --help  show this help message and exit
+  -o file     output file (default: system.dic)
+  -d string   description comment to be embedded on dictionary
+
+required named arguments:
+  -m file     connection matrix file with MeCab's matrix.def format
+```
+```
+$ sudachipy ubuild -h
+usage: sudachipy ubuild [-h] [-d string] [-o file] [-s file] file [file ...]
+
+Build User Dictionary
+
+positional arguments:
+  file        source files with CSV format (one or more)
+
+optional arguments:
+  -h, --help  show this help message and exit
+  -d string   description comment to be embedded on dictionary
+  -o file     output file (default: user.dic)
+  -s file     system dictionary (default: ${SUDACHIPY}/resouces/system.dic)
 
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,15 @@
+import os
 from setuptools import setup
 
+
 def readme():
-      with open("README.md", encoding="utf-8") as f:
-            return f.read()
+    with open("README.md", encoding="utf-8") as f:
+        return f.read()
+
+
+this_dir = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(this_dir, 'requirements.txt'), 'r') as rf:
+    install_requires = [line for line in rf.read().splitlines() if not line.startswith('#')]
 
 setup(name="SudachiPy",
       version="0.1.0",
@@ -15,4 +22,5 @@ setup(name="SudachiPy",
             "console_scripts": ["sudachipy=sudachipy.command_line:main"],
       },
       include_package_data=True,
+      install_requires=install_requires
       )

--- a/sudachipy/command_line.py
+++ b/sudachipy/command_line.py
@@ -63,9 +63,7 @@ def _matrix_file_checker(args, print_usage):
 
 
 def _command_user_build(args, print_usage):
-    # system dictionary
     _system_dic_checker(args, print_usage)
-    # input files
     _input_files_checker(args, print_usage)
     header = DictionaryHeader(
         DictionaryVersion.USER_DICT_VERSION_2, int(time.time()), args.description)
@@ -77,9 +75,7 @@ def _command_user_build(args, print_usage):
 
 
 def _command_build(args, print_usage):
-    # matrix
     _matrix_file_checker(args, print_usage)
-    # input files
     _input_files_checker(args, print_usage)
     header = DictionaryHeader(
         DictionaryVersion.SYSTEM_DICT_VERSION, int(time.time()), args.description)

--- a/sudachipy/command_line.py
+++ b/sudachipy/command_line.py
@@ -5,14 +5,13 @@ import os
 import sys
 import time
 
+from . import config
+from . import dictionary
+from . import tokenizer
 from .dictionarylib.dictionarybuilder import DictionaryBuilder
 from .dictionarylib.dictionaryheader import DictionaryHeader
 from .dictionarylib.dictionaryversion import DictionaryVersion
 from .dictionarylib.userdictionarybuilder import UserDictionaryBuilder
-
-from . import config
-from . import dictionary
-from . import tokenizer
 
 
 def run(tokenizer, mode, input, output, print_all):
@@ -174,14 +173,15 @@ def main():
 
 # Todo: delete this function in the future
 def _read_system_dictionary(filename):
-    from dictionarylib.dictionaryversion import DictionaryVersion
+    from .dictionarylib.dictionaryversion import DictionaryVersion
+    from .dictionarylib.dictionaryheader import DictionaryHeader
+    from . import dictionarylib
     """
     Copy of sudachipy.dictionary.Dictionary.read_system_dictionary
     :param filename:
     :return:
     """
     import mmap
-    from sudachipy import dictionarylib
     buffers = []
     if filename is None:
         raise AttributeError("system dictionary is not specified")
@@ -190,7 +190,7 @@ def _read_system_dictionary(filename):
     buffers.append(bytes_)
 
     offset = 0
-    header = dictionarylib.dictionaryheader.DictionaryHeader.from_bytes(bytes_, offset)
+    header = DictionaryHeader.from_bytes(bytes_, offset)
     if header.version != DictionaryVersion.SYSTEM_DICT_VERSION:
         raise Exception("invalid system dictionary")
     offset += header.storage_size()

--- a/sudachipy/command_line.py
+++ b/sudachipy/command_line.py
@@ -1,7 +1,14 @@
 import argparse
 import fileinput
 import json
+import os
 import sys
+import time
+
+from .dictionarylib.dictionarybuilder import DictionaryBuilder
+from .dictionarylib.dictionaryheader import DictionaryHeader
+from .dictionarylib.dictionaryversion import DictionaryVersion
+from .dictionarylib.userdictionarybuilder import UserDictionaryBuilder
 
 from . import config
 from . import dictionary
@@ -27,17 +34,63 @@ def run(tokenizer, mode, input, output, print_all):
         print("EOS", file=output)
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Japanese Morphological Analyzer")
-    parser.add_argument("-r", dest="fpath_setting", metavar="file",
-                        default=config.SETTINGFILE, help="the setting file in JSON format")
-    parser.add_argument("-m", dest="mode", choices=["A", "B", "C"], default="C", help="the mode of splitting")
-    parser.add_argument("-o", dest="fpath_out", metavar="file", help="the output file")
-    parser.add_argument("-a", action="store_true", help="print all of the fields")
-    parser.add_argument("-d", action="store_true", help="print the debug information")
-    parser.add_argument("-v", "--version", action="version", version="%(prog)s 0.1.0")
-    parser.add_argument("input_files", metavar="input file(s)", nargs=argparse.REMAINDER)
-    args = parser.parse_args()
+def _system_dic_checker(args, print_usage):
+    if not args.system_dic:
+        args.system_dic = os.path.join(os.path.dirname(
+            os.path.abspath(__file__)), os.pardir, 'resources/system.dic')
+    if not os.path.exists(args.system_dic):
+        print_usage()
+        print('{}: error: {} doesn\'t exist'.format(__name__, args.system_dic))
+        exit()
+
+
+def _input_files_checker(args, print_usage):
+    if not args.in_files:
+        print_usage()
+        print('{}: error: no input files'.format(__name__))
+        exit()
+    for file in args.in_files:
+        if not os.path.exists(file):
+            print_usage()
+            print('{}: error: {} doesn\'t exist'.format(__name__, file))
+            exit()
+
+
+def _matrix_file_checker(args, print_usage):
+    if not os.path.exists(args.matrix_file):
+        print_usage()
+        print('{}: error: {} doesn\'t exist'.format(__name__, args.matrix_file))
+        exit()
+
+
+def _command_user_build(args, print_usage):
+    # system dictionary
+    _system_dic_checker(args, print_usage)
+    # input files
+    _input_files_checker(args, print_usage)
+    header = DictionaryHeader(
+        DictionaryVersion.USER_DICT_VERSION_2, int(time.time()), args.description)
+    _, _, grammar, system_lexicon = _read_system_dictionary(args.system_dic)
+    with open(args.out_file, 'wb') as wf:
+        wf.write(header.to_bytes())
+        builder = UserDictionaryBuilder(grammar, system_lexicon)
+        builder.build(args.in_files, None, wf)
+
+
+def _command_build(args, print_usage):
+    # matrix
+    _matrix_file_checker(args, print_usage)
+    # input files
+    _input_files_checker(args, print_usage)
+    header = DictionaryHeader(
+        DictionaryVersion.SYSTEM_DICT_VERSION, int(time.time()), args.description)
+    with open(args.out_file, 'wb') as wf, open(args.matrix_file, 'r') as rf:
+        wf.write(header.to_bytes())
+        builder = DictionaryBuilder()
+        builder.build(args.in_files, rf, wf)
+
+
+def _command_tokenize(args, print_usage):
 
     with open(args.fpath_setting, "r", encoding="utf-8") as f:
         settings = json.load(f)
@@ -66,6 +119,87 @@ def main():
     run(tokenizer_obj, mode, input_, output, print_all)
 
     output.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Japanese Morphological Analyzer")
+    subparsers = parser.add_subparsers()
+
+    # root parser
+    parser.add_argument("-v", "--version", action="version", version="%(prog)s v0.1.1")
+
+    # tokenize parser
+    parser_tk = subparsers.add_parser('tokenize', help='see `tokenize -h`', description='Japanese Morphological Analyze')
+    parser_tk.add_argument("-r", dest="fpath_setting", metavar="file",
+                           default=config.SETTINGFILE, help="the setting file in JSON format")
+    parser_tk.add_argument("-m", dest="mode", choices=["A", "B", "C"], default="C", help="the mode of splitting")
+    parser_tk.add_argument("-o", dest="fpath_out", metavar="file", help="the output file")
+    parser_tk.add_argument("-a", action="store_true", help="print all of the fields")
+    parser_tk.add_argument("-d", action="store_true", help="print the debug information")
+    parser_tk.add_argument("input_files", metavar="input file(s)", nargs=argparse.REMAINDER)
+    parser_tk.set_defaults(handler=_command_tokenize, print_usage=parser_tk.print_usage)
+
+    # build dictionary parser
+    parser_bd = subparsers.add_parser('build', help='see `build -h`', description='Build Sudachi Dictionary')
+    parser_bd.add_argument('-o', dest='out_file', metavar='file', default='system.dic',
+                           help='output file (default: system.dic)')
+    parser_bd.add_argument('-d', dest='description', default='', metavar='string', required=False,
+                           help='description comment to be embedded on dictionary')
+    required_named_bd = parser_bd.add_argument_group('required named arguments')
+    required_named_bd.add_argument('-m', dest='matrix_file', metavar='file', required=True,
+                                   help='connection matrix file with MeCab\'s matrix.def format')
+    parser_bd.add_argument("in_files", metavar="file", nargs=argparse.ONE_OR_MORE,
+                           help='source files with CSV format (one of more)')
+    parser_bd.set_defaults(handler=_command_build, print_usage=parser_bd.print_usage)
+
+    # build user-dictionary parser
+    parser_ubd = subparsers.add_parser('ubuild', help='see `ubuild -h`', description='Build User Dictionary')
+    parser_ubd.add_argument('-d', dest='description', default='', metavar='string', required=False,
+                            help='description comment to be embedded on dictionary')
+    parser_ubd.add_argument('-o', dest='out_file', metavar='file', default='user.dic',
+                            help='output file (default: user.dic)')
+    parser_ubd.add_argument('-s', dest='system_dic', metavar='file', required=False,
+                            help='system dictionary (default: ${SUDACHIPY}/resouces/system.dic)')
+    parser_ubd.add_argument("in_files", metavar="file", nargs=argparse.ONE_OR_MORE,
+                            help='source files with CSV format (one or more)')
+    parser_ubd.set_defaults(handler=_command_user_build, print_usage=parser_ubd.print_usage)
+
+    args = parser.parse_args()
+
+    if hasattr(args, 'handler'):
+        args.handler(args, args.print_usage)
+    else:
+        parser.print_help()
+
+
+# Todo: delete this function in the future
+def _read_system_dictionary(filename):
+    from dictionarylib.dictionaryversion import DictionaryVersion
+    """
+    Copy of sudachipy.dictionary.Dictionary.read_system_dictionary
+    :param filename:
+    :return:
+    """
+    import mmap
+    from sudachipy import dictionarylib
+    buffers = []
+    if filename is None:
+        raise AttributeError("system dictionary is not specified")
+    with open(filename, 'r+b') as system_dic:
+        bytes_ = mmap.mmap(system_dic.fileno(), 0, access=mmap.ACCESS_READ)
+    buffers.append(bytes_)
+
+    offset = 0
+    header = dictionarylib.dictionaryheader.DictionaryHeader.from_bytes(bytes_, offset)
+    if header.version != DictionaryVersion.SYSTEM_DICT_VERSION:
+        raise Exception("invalid system dictionary")
+    offset += header.storage_size()
+
+    grammar = dictionarylib.grammar.Grammar(bytes_, offset)
+    offset += grammar.get_storage_size()
+
+    lexicon = dictionarylib.lexiconset.LexiconSet(dictionarylib.doublearraylexicon.DoubleArrayLexicon(bytes_, offset))
+    return buffers, header, grammar, lexicon
 
 
 if __name__ == '__main__':

--- a/sudachipy/dictionarylib/dictionaryheader.py
+++ b/sudachipy/dictionarylib/dictionaryheader.py
@@ -29,7 +29,7 @@ class DictionaryHeader:
     def to_bytes(self):
         buf = JTypedByteBuffer(b'\x00' * (16 + self.__DESCRIPTION_SIZE))
         buf.seek(0)
-        buf.write_int(self.version, 'long')
+        buf.write_int(self.version, 'long', signed=False)
         buf.write_int(self.create_time, 'long')
         bdesc = self.description.encode('utf-8')
         if len(bdesc) > self.__DESCRIPTION_SIZE:

--- a/sudachipy/dictionarylib/dictionaryversion.py
+++ b/sudachipy/dictionarylib/dictionaryversion.py
@@ -19,5 +19,9 @@ class _DictionaryVersion:
     def USER_DICT_VERSION():
         return 0xa50f31188bd211e7
 
+    @constant
+    def USER_DICT_VERSION_2():
+        return 0x9fdeb5a90168d868
+
 
 DictionaryVersion = _DictionaryVersion()

--- a/sudachipy/dictionarylib/userdictionarybuilder.py
+++ b/sudachipy/dictionarylib/userdictionarybuilder.py
@@ -20,7 +20,7 @@ class UserDictionaryBuilder(DictionaryBuilder):
         for path in lexicon_paths:
             with open(path) as rf:
                 self.build_lexicon(rf)
-            self.logger.info('{} words\n'.format(len(self.entries)))
+        self.logger.info('{} words\n'.format(len(self.entries)))
 
         self.write_grammar(None, out_stream)
         self.write_lexicon(out_stream)


### PR DESCRIPTION
I changed command line interface.

example
```bash
$sudachipy
usage: sudachipy [-h] [-v] {tokenize,build,ubuild} ...

Japanese Morphological Analyzer

positional arguments:
  {tokenize,build,ubuild}
    tokenize            see `tokenize -h`
    build               see `build -h`
    ubuild              see `ubuild -h`

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
```
```bash
$ sudachipy tokenize -h
usage: sudachipy tokenize [-h] [-r file] [-m {A,B,C}] [-o file] [-a] [-d] ...

Japanese Morphological Analyze

positional arguments:
  input file(s)

optional arguments:
  -h, --help     show this help message and exit
  -r file        the setting file in JSON format
  -m {A,B,C}     the mode of splitting
  -o file        the output file
  -a             print all of the fields
  -d             print the debug information
```
```bash
$ sudachipy build -h
usage: sudachipy build [-h] [-o file] [-d string] -m file file [file ...]

Build Sudachi Dictionary

positional arguments:
  file        source files with CSV format (one of more)

optional arguments:
  -h, --help  show this help message and exit
  -o file     output file (default: system.dic)
  -d string   description comment to be embedded on dictionary

required named arguments:
  -m file     connection matrix file with MeCab's matrix.def format
```
```bash
$ sudachipy ubuild -h
usage: sudachipy ubuild [-h] [-d string] [-o file] [-s file] file [file ...]

Build User Dictionary

positional arguments:
  file        source files with CSV format (one or more)

optional arguments:
  -h, --help  show this help message and exit
  -d string   description comment to be embedded on dictionary
  -o file     output file (default: user.dic)
  -s file     system dictionary (default: ${SUDACHIPY}/resouces/system.dic)
```
```bash
$ sudachipy tokenize test.txt 
私	代名詞,*,*,*,*,*	私
は	助詞,係助詞,*,*,*,*	は
日本人	名詞,普通名詞,一般,*,*,*	日本人
です	助動詞,*,*,*,助動詞-デス,終止形-一般	です
よ	助詞,終助詞,*,*,*,*	よ
。	補助記号,句点,*,*,*,*	。
EOS
```
```bash
$ sudachipy ubuild dict/lex.csv dict/user2.csv
reading the source file...38 words
writing the POS table...2 bytes
writing the connection matrix...4 bytes
building the trie...done
writing the trie...3076 bytes
writing the word-ID table...193 bytes
writing the word parameters...232 bytes
writing the word_infos...2541 bytes
writing word_info offsets...152 bytes
```
```bash
$ sudachipy build -m dict/matrix.def dict/lex.csv dict/user2.csv
reading the source file...38 words
writing the POS table...266 bytes
writing the connection matrix...204 bytes
building the trie...done
writing the trie...3076 bytes
writing the word-ID table...193 bytes
writing the word parameters...232 bytes
writing the word_infos...2541 bytes
writing word_info offsets...152 bytes

```