### PR TITLE
fix: fixed logger TypeError issue

### DIFF
--- a/sudachipy/dictionarylib/dictionarybuilder.py
+++ b/sudachipy/dictionarylib/dictionarybuilder.py
@@ -226,7 +226,7 @@ class DictionaryBuilder(object):
 
         def progress_func(n, s):
             if (n % (s / 10 + 1)) == 0:
-                self.logger('.')
+                self.logger.info('.')
         trie.build(keys, vals, progress_func)
         self.logger.info('done\n')
 


### PR DESCRIPTION
Hi guys

I found that if build custom dictionary with specific lines, such a 24 lines, will trigger this issue

```
  File "/Users/allovince/.pyenv/versions/3.7.3/lib/python3.7/site-packages/sudachipy/dictionarylib/dictionarybuilder.py", line 229, in progress_func
    self.logger('.')
TypeError: 'Logger' object is not callable
```

Here is my test code

```python
from sudachipy import dictionarylib
from sudachipy.dictionarylib.userdictionarybuilder import UserDictionaryBuilder
import os
import time
from importlib import import_module
from pathlib import Path

dict_content = '''御懇意,5146,5146,8000,御懇意,名詞,固有名詞,一般,*,*,*,ごこんい,御懇意,*,*,*,*,*
此校,5146,5146,8000,此校,名詞,固有名詞,一般,*,*,*,ここ,此校,*,*,*,*,*
此所,5146,5146,8000,此所,名詞,固有名詞,一般,*,*,*,ここ,此所,*,*,*,*,*
跡続,5146,5146,8000,跡続,名詞,固有名詞,一般,*,*,*,あとつ,跡続,*,*,*,*,*
其所,5146,5146,8000,其所,名詞,固有名詞,一般,*,*,*,そこ,其所,*,*,*,*,*
貼出,5146,5146,8000,貼出,名詞,固有名詞,一般,*,*,*,はりだ,貼出,*,*,*,*,*
真闇,5146,5146,8000,真闇,名詞,固有名詞,一般,*,*,*,まっくら,真闇,*,*,*,*,*
本統,5146,5146,8000,本統,名詞,固有名詞,一般,*,*,*,ほんとう,本統,*,*,*,*,*
何時,5146,5146,8000,何時,名詞,固有名詞,一般,*,*,*,いつ,何時,*,*,*,*,*
好加減,5146,5146,8000,好加減,名詞,固有名詞,一般,*,*,*,いいかげん,好加減,*,*,*,*,*
御手際,5146,5146,8000,御手際,名詞,固有名詞,一般,*,*,*,おてぎわ,御手際,*,*,*,*,*
茲処,5146,5146,8000,茲処,名詞,固有名詞,一般,*,*,*,ここ,茲処,*,*,*,*,*
熟々,5146,5146,8000,熟々,名詞,固有名詞,一般,*,*,*,つくづく,熟々,*,*,*,*,*
一束,5146,5146,8000,一束,名詞,固有名詞,一般,*,*,*,ひとたば,一束,*,*,*,*,*
十把一,5146,5146,8000,十把一,名詞,固有名詞,一般,*,*,*,じっぱひと,十把一,*,*,*,*,*
御能,5146,5146,8000,御能,名詞,固有名詞,一般,*,*,*,おのう,御能,*,*,*,*,*
究屈,5146,5146,8000,究屈,名詞,固有名詞,一般,*,*,*,きゅうくつ,究屈,*,*,*,*,*
古臭,5146,5146,8000,古臭,名詞,固有名詞,一般,*,*,*,ふるくさ,古臭,*,*,*,*,*
二色,5146,5146,8000,二色,名詞,固有名詞,一般,*,*,*,ふたいろ,二色,*,*,*,*,*
所刑,5146,5146,8000,所刑,名詞,固有名詞,一般,*,*,*,しょけい,所刑,*,*,*,*,*
遣口,5146,5146,8000,遣口,名詞,固有名詞,一般,*,*,*,やりくち,遣口,*,*,*,*,*
遣方,5146,5146,8000,遣方,名詞,固有名詞,一般,*,*,*,やりかた,遣方,*,*,*,*,*
恐露病,5146,5146,8000,恐露病,名詞,固有名詞,一般,*,*,*,きょうろびょう,恐露病,*,*,*,*,*
御遣,5146,5146,8000,御遣,名詞,固有名詞,一般,*,*,*,おや,御遣,*,*,*,*,*
'''

my_dict_dir = os.path.abspath(os.path.dirname(__file__))
system_dict_path = Path(import_module('sudachidict').__file__).parent
system_dict_path = os.path.join(system_dict_path, 'resources', 'system.dic')
system_dict = dictionarylib.BinaryDictionary.from_system_dictionary(system_dict_path)
with open(my_dict_dir + '/my_dict.csv', 'w', encoding='utf-8') as wf:
    wf.write(dict_content)

header = dictionarylib.dictionaryheader.DictionaryHeader(
    dictionarylib.USER_DICT_VERSION_2, int(time.time()), 'my_dict')
with open(my_dict_dir + '/my_dict.dic', 'wb') as wf:
    wf.write(header.to_bytes())
    builder = UserDictionaryBuilder(system_dict.grammar,
                                    system_dict.lexicon, )
    builder.build([my_dict_dir + '/my_dict.csv'], None, wf)
```

It looks like a missing typo, hope this will be helped