### PR TITLE
feat: unuse symlink & use resoources/sudachi.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ $ pip install SudachiPy
 SudachiPy(>=v0.3.0) refers to system.dic of SudachiDict_core (not included in SudachiPy) package by default.
 Please proceed to Step 2 to install the dict package.
 
-### Step 2: Install SudachiDict_core
+### Step 2: Install & link SudachiDict_core
 
 The default dict package `SudachiDict_core` is distributed from our download site.
-Run `pip install` like below:
+You can download using pip. After that you need to link the package to sudachipy using `link` command. 
 
 ```bash
 $ pip install https://object-storage.tyo2.conoha.io/v1/nc_2520839e1f9641b08211a5c85243124a/sudachi/SudachiDict_core-20191030.tar.gz
+$ sudachipy link core
 ```
 
 ## Usage
@@ -66,14 +67,15 @@ optional arguments:
 ```
 ```bash
 $ sudachipy link -h
-usage: sudachipy link [-h] [-t {small,core,full}] [-u]
+usage: sudachipy link [-h] keyword
 
-Link Default Dict Package
+Link Dictionary Package
+
+positional arguments:
+  keyword      {small, core, full}
 
 optional arguments:
-  -h, --help            show this help message and exit
-  -t {small,core,full}  dict dict
-  -u                    unlink sudachidict
+  -h, --help  show this help message and exit
 ```
 ```bash
 $ sudachipy build -h

--- a/sudachipy/dictionary.py
+++ b/sudachipy/dictionary.py
@@ -22,6 +22,12 @@ from .plugin.path_rewrite import get_path_rewrite_plugins
 from .tokenizer import Tokenizer
 
 
+class UndefinedDict(Exception):
+    def __init__(self, msg=None, code=None):
+        self.msg = msg
+        self.code = code
+
+
 class Dictionary:
 
     def __init__(self, config_path=None, resource_dir=None):
@@ -34,8 +40,10 @@ class Dictionary:
         self.path_rewrite_plugins = []
         self.dictionaries = []
         self.header = None
-        self._read_system_dictionary(config.settings.system_dict_path())
-
+        try:
+            self._read_system_dictionary(config.settings.system_dict_path())
+        except (FileNotFoundError, IsADirectoryError, KeyError) as e:
+            raise UndefinedDict(e)
         # self.edit_connection_plugin = [InhibitConnectionPlugin()]
         # for p in self.edit_connection_plugin:
         #     p.set_up(self.grammar)
@@ -62,7 +70,7 @@ class Dictionary:
 
     def _read_system_dictionary(self, filename):
         if filename is None:
-            raise AttributeError("system dictionary is not specified")
+            raise ValueError("system dictionary is not specified")
         dict_ = BinaryDictionary.from_system_dictionary(filename)
         self.dictionaries.append(dict_)
         self.grammar = dict_.grammar

--- a/sudachipy/resources/sudachi.json
+++ b/sudachipy/resources/sudachi.json
@@ -1,4 +1,5 @@
 {
+    "systemDict" : "",
     "characterDefinitionFile" : "char.def",
     "inputTextPlugin" : [
         { "class" : "sudachipy.plugin.input_text.DefaultInputTextPlugin" },


### PR DESCRIPTION
Related #100 #107 

Instead of using symlink, rewrire configuration file in resouces directory to change system dictionary.

Interface improved a little. I think it won't make trouble in  users environment.
```bash
$ pip install sudachipy
$ sudachipy YOUR_TEXT_FILE
Dictionary not linked properly.
1. download dictionary -> see https://github.com/WorksApplications/SudachiPy
2. run link command -> e.g "sudachipy link core"
or you can use self-defined configuration file (but now undocumented).
$ sudachipy link core
sudachidict_core not installed. Check out how to install dictionary package at https://github.com
$ pip install SUDACHI_DICT_CORE_URL
$ sudachipy link core
$ sudachipy YOUR_TEXT_FILE
...SUCCESS...
```