### PR TITLE
Fix connection cost lookup, fix #129

### DIFF
--- a/sudachipy/lattice.pyx
+++ b/sudachipy/lattice.pyx
@@ -94,7 +94,6 @@ cdef class Lattice:
         for l_node in self.end_lists[begin]:
             if not l_node.is_connected_to_bos:
                 continue
-            # right_id and left_id look reversed, but it works ...
             connect_cost = self.connect_costs[r_node.left_id, l_node.right_id]
 
             # 0x7fff == Grammar.INHIBITED_CONNECTION:

--- a/sudachipy/lattice.pyx
+++ b/sudachipy/lattice.pyx
@@ -95,7 +95,7 @@ cdef class Lattice:
             if not l_node.is_connected_to_bos:
                 continue
             # right_id and left_id look reversed, but it works ...
-            connect_cost = self.connect_costs[l_node.right_id, r_node.left_id]
+            connect_cost = self.connect_costs[r_node.left_id, l_node.right_id]
 
             # 0x7fff == Grammar.INHIBITED_CONNECTION:
             if connect_cost == 0x7fff:


### PR DESCRIPTION
The connection costs lookup was backwards.

There was a comment in the pre-cython code that the call to the cost
lookup function looked backwards, but was actually correct. It was
calling with (l_node.right_id, r_node.left_id). I kept this order when I
replaced the function call with a memoryview access, but that was wrong;
I hadn't noticed that the access function was actually reversing the
order of its arguments.

This fix was verified by checking the tokenization of a short document
vs v0.4.5 and making sure there were no changes.