### PR TITLE
Open the system dictionary in the binary read mode

### DIFF
--- a/sudachipy/dictionarylib/binarydictionary.py
+++ b/sudachipy/dictionarylib/binarydictionary.py
@@ -30,7 +30,7 @@ class BinaryDictionary(object):
 
     @staticmethod
     def _read_dictionary(filename, access=mmap.ACCESS_READ):
-        with open(filename, 'r+b') as system_dic:
+        with open(filename, 'rb') as system_dic:
             bytes_ = mmap.mmap(system_dic.fileno(), 0, access=access)
         offset = 0
         header = DictionaryHeader.from_bytes(bytes_, offset)


### PR DESCRIPTION
Suppose the case when installing sudachipy and its dictionary under the system-wide location, such as "/usr/local/lib/python3.7/dist-packages/" using the following command:

```
$ sudo pip3 install sudachipy sudachidict_full
$ sudo sudachipy link -t full
```

When invoking sudachipy in the above case, I saw the following error.

```
$ sudachipy 
Traceback (most recent call last):
  File "/usr/local/bin/sudachipy", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/dist-packages/sudachipy/command_line.py", line 236, in main
    args.handler(args, args.print_usage)
  File "/usr/local/lib/python3.7/dist-packages/sudachipy/command_line.py", line 171, in _command_tokenize
    dict_ = dictionary.Dictionary(config_path=args.fpath_setting)
  File "/usr/local/lib/python3.7/dist-packages/sudachipy/dictionary.py", line 37, in __init__
    self._read_system_dictionary(config.settings.system_dict_path())
  File "/usr/local/lib/python3.7/dist-packages/sudachipy/dictionary.py", line 66, in _read_system_dictionary
    dict_ = BinaryDictionary.from_system_dictionary(filename)
  File "/usr/local/lib/python3.7/dist-packages/sudachipy/dictionarylib/binarydictionary.py", line 50, in from_system_dictionary
    args = cls._read_dictionary(filename)
  File "/usr/local/lib/python3.7/dist-packages/sudachipy/dictionarylib/binarydictionary.py", line 33, in _read_dictionary
    with open(filename, 'r+b') as system_dic:
PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.7/dist-packages/sudachidict/resources/system.dic'
```

In order to resolve this error, the attached patch is effective.