### PR TITLE
Feature changing dictionary linking mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ EOS
 
 ```bash
 $ sudachipy tokenize -h
-usage: sudachipy tokenize [-h] [-r file] [-m {A,B,C}] [-o file] [-a] [-d] [-v]
+usage: sudachipy tokenize [-h] [-r file] [-m {A,B,C}] [-o file] [-s string]
+                          [-a] [-d] [-v]
                           [file [file ...]]
 
 Tokenize Text
@@ -83,6 +84,7 @@ optional arguments:
   -r file        the setting file in JSON format
   -m {A,B,C}     the mode of splitting
   -o file        the output file
+  -s string      sudachidict type
   -a             print all of the fields
   -d             print the debug information
   -v, --version  print sudachipy version
@@ -175,33 +177,71 @@ tokenizer_obj.tokenize("シュミレーション", mode)[0].normalized_form()
 
 ## Dictionary Edition
 
+**WARNING: `sudachipy link` is no longer available in SudachiPy v0.5.2 and later. **
+
+
 There are three editions of Sudachi Dictionary, namely, `small`, `core`, and `full`. See [WorksApplications/SudachiDict](https://github.com/WorksApplications/SudachiDict) for the detail.
 
-SudachiPy uses `sudachidict_core` by default. You can specify the dictionary with the `link -t` command.
+SudachiPy uses `sudachidict_core` by default. 
 
-```bash
-$ pip install sudachidict_small
-$ sudachipy link -t small
-```
-
-```bash
-$ pip install sudachidict_full
-$ sudachipy link -t full
-```
-
-You can remove the dictionary link with the `link -u` commnad.
-
-```bash
-$ sudachipy link -u
-```
-
-Dictionaries are installed as Python packages `sudachidict_small`, `sudachidict_core`, and `sudachidict_full`. SudachiPy tries to refer `sudachidict` package to use a dictionary. The `link` subcommand creates *a symbolic link* of `sudachidict_*` as `sudachidict`, to switch the packages.
+Dictionaries are installed as Python packages `sudachidict_small`, `sudachidict_core`, and `sudachidict_full`.
 
 * [SudachiDict-small · PyPI](https://pypi.org/project/SudachiDict-small/)
 * [SudachiDict-core · PyPI](https://pypi.org/project/SudachiDict-core/)
 * [SudachiDict-full · PyPI](https://pypi.org/project/SudachiDict-full/)
 
 The dictionary files are not in the package itself, but it is downloaded upon installation.
+
+### Dictionary option: command line
+
+You can specify the dictionary with the tokenize option `-s`.
+
+```bash
+$ pip install sudachidict_small
+$ echo "外国人参政権" | sudachipy -s small
+```
+
+```bash
+$ pip install sudachidict_full
+$ echo "外国人参政権" | sudachipy -s full
+```
+
+### Dictionary option: Python package
+
+You can specify the dictionary with the `Dicionary()` argument; `config_path` or `dict_type`.
+
+```python
+class Dictionary(config_path=None, resource_dir=None, dict_type=None)
+```
+
+1. `config_path`
+    * You can specify the file path to the setting file with `config_path` (See [Dictionary in The Setting File](#Dictionary in The Setting File) for the detail).
+    * If the dictionary file is specified in the setting file as `systemDict`, SudachiPy will use the dictionary.
+2. `dict_type`
+    * You can also specify the dictionary type with `dict_type`.
+    * The available arguments are `small`, `core`, or `full`.
+    * If different dictionaries are specified with `config_path` and `dict_type`, **a dictionary defined `dict_type` overrides** those defined in the config path.
+
+```python
+from sudachipy import tokenizer
+from sudachipy import dictionary
+
+# default: sudachidict_core
+tokenizer_obj = dictionary.Dictionary().create()  
+
+# The dictionary given by the `systemDict` key in the config file (/path/to/sudachi.json) will be used
+tokenizer_obj = dictionary.Dictionary(config_path="/path/to/sudachi.json").create()  
+
+# The dictionary specified by `dict_type` will be set.
+tokenizer_obj = dictionary.Dictionary(dict_type="core").create()  # sudachidict_core (same as default)
+tokenizer_obj = dictionary.Dictionary(dict_type="small").create()  # sudachidict_small
+tokenizer_obj = dictionary.Dictionary(dict_type="full").create()  # sudachidict_full
+
+# The dictionary specified by `dict_type` overrides those defined in the config path.
+# In the following code, `sudachidict_full` will be used regardless of a dictionary defined in the config file. 
+tokenizer_obj = dictionary.Dictionary(config_path="/path/to/sudachi.json", dict_type="full").create()  
+```
+
 
 ### Dictionary in The Setting File
 
@@ -256,7 +296,7 @@ optional arguments:
   -h, --help  show this help message and exit
   -d string   description comment to be embedded on dictionary
   -o file     output file (default: user.dic)
-  -s file     system dictionary (default: linked system_dic, see link -h)
+  -s file     system dictionary (default: core dic)
 ```
 
 About the dictionary file format, please refer to [this document](https://github.com/WorksApplications/Sudachi/blob/develop/docs/user_dict.md) (written in Japanese, English version is not available yet).

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ optional arguments:
   -h, --help  show this help message and exit
   -d string   description comment to be embedded on dictionary
   -o file     output file (default: user.dic)
-  -s file     system dictionary (default: core dic)
+  -s file     system dictionary path (default: system core dictionary path)
 ```
 
 About the dictionary file format, please refer to [this document](https://github.com/WorksApplications/Sudachi/blob/develop/docs/user_dict.md) (written in Japanese, English version is not available yet).

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -293,7 +293,7 @@ optional arguments:
   -h, --help  show this help message and exit
   -d string   description comment to be embedded on dictionary
   -o file     output file (default: user.dic)
-  -s file     system dictionary (default: core dic)
+  -s file     system dictionary path (default: system core dictionary path)
 ```
 
 辞書ファイル形式については[user_dict.md](https://github.com/WorksApplications/Sudachi/blob/develop/docs/user_dict.md)を参照してください。 

--- a/sudachipy/command_line.py
+++ b/sudachipy/command_line.py
@@ -22,7 +22,7 @@ import time
 from . import __version__
 from . import dictionary
 from . import tokenizer
-from .config import set_default_dict_package, settings, unlink_default_dict_package
+from .config import settings
 from .dictionarylib import BinaryDictionary
 from .dictionarylib import SYSTEM_DICT_VERSION_2, USER_DICT_VERSION_3
 from .dictionarylib.dictionarybuilder import DictionaryBuilder
@@ -125,22 +125,6 @@ def _command_build(args, print_usage):
         builder.build(args.in_files, rf, wf)
 
 
-def _command_link(args, print_usage):
-    output = sys.stdout
-    if args.unlink:
-        unlink_default_dict_package(output=output)
-        return
-
-    dict_package = 'sudachidict_' + args.dict_type
-    try:
-        return set_default_dict_package(dict_package, output=output)
-    except ImportError:
-        print('Package `{0}` does not exist.\n'
-              'You may install it with a command `$ pip install {0}`'
-              .format(dict_package), file=sys.stderr)
-        exit(1)
-
-
 def _command_tokenize(args, print_usage):
     if args.version:
         print_version()
@@ -169,7 +153,11 @@ def _command_tokenize(args, print_usage):
     enable_dump = args.d
 
     try:
-        dict_ = dictionary.Dictionary(config_path=args.fpath_setting)
+        if args.system_dict_type is not None:
+            print("args.system_dict_type", args.system_dict_type, flush=True)
+            dict_ = dictionary.Dictionary(config_path=args.fpath_setting, dict_type=args.system_dict_type)
+        else:
+            dict_ = dictionary.Dictionary(config_path=args.fpath_setting)
         tokenizer_obj = dict_.create()
         input_ = fileinput.input(args.in_files, openhook=fileinput.hook_encoded("utf-8"))
         run(tokenizer_obj, mode, input_, print_all, stdout_logger, enable_dump)
@@ -192,17 +180,13 @@ def main():
     parser_tk.add_argument("-r", dest="fpath_setting", metavar="file", help="the setting file in JSON format")
     parser_tk.add_argument("-m", dest="mode", choices=["A", "B", "C"], default="C", help="the mode of splitting")
     parser_tk.add_argument("-o", dest="fpath_out", metavar="file", help="the output file")
+    parser_tk.add_argument("-s", dest="system_dict_type", metavar='string', choices=["small", "core", "full"],
+                           help="sudachidict type")
     parser_tk.add_argument("-a", action="store_true", help="print all of the fields")
     parser_tk.add_argument("-d", action="store_true", help="print the debug information")
     parser_tk.add_argument("-v", "--version", action="store_true", dest="version", help="print sudachipy version")
     parser_tk.add_argument("in_files", metavar="file", nargs=argparse.ZERO_OR_MORE, help='text written in utf-8')
     parser_tk.set_defaults(handler=_command_tokenize, print_usage=parser_tk.print_usage)
-
-    # link default dict package
-    parser_ln = subparsers.add_parser('link', help='see `link -h`', description='Link Default Dict Package')
-    parser_ln.add_argument("-t", dest="dict_type", choices=["small", "core", "full"], default="core", help="dict dict")
-    parser_ln.add_argument("-u", dest="unlink", action="store_true", help="unlink sudachidict")
-    parser_ln.set_defaults(handler=_command_link, print_usage=parser_ln.print_usage)
 
     # build dictionary parser
     parser_bd = subparsers.add_parser('build', help='see `build -h`', description='Build Sudachi Dictionary')

--- a/sudachipy/command_line.py
+++ b/sudachipy/command_line.py
@@ -207,7 +207,7 @@ def main():
     parser_ubd.add_argument('-o', dest='out_file', metavar='file', default='user.dic',
                             help='output file (default: user.dic)')
     parser_ubd.add_argument('-s', dest='system_dic', metavar='file', required=False,
-                            help='system dictionary (default: core dic)')
+                            help='system dictionary path (default: system core dictionary path)')
     parser_ubd.add_argument("in_files", metavar="file", nargs=argparse.ONE_OR_MORE,
                             help='source files with CSV format (one or more)')
     parser_ubd.set_defaults(handler=_command_user_build, print_usage=parser_ubd.print_usage)

--- a/sudachipy/command_line.py
+++ b/sudachipy/command_line.py
@@ -154,7 +154,6 @@ def _command_tokenize(args, print_usage):
 
     try:
         if args.system_dict_type is not None:
-            print("args.system_dict_type", args.system_dict_type, flush=True)
             dict_ = dictionary.Dictionary(config_path=args.fpath_setting, dict_type=args.system_dict_type)
         else:
             dict_ = dictionary.Dictionary(config_path=args.fpath_setting)

--- a/sudachipy/command_line.py
+++ b/sudachipy/command_line.py
@@ -207,7 +207,7 @@ def main():
     parser_ubd.add_argument('-o', dest='out_file', metavar='file', default='user.dic',
                             help='output file (default: user.dic)')
     parser_ubd.add_argument('-s', dest='system_dic', metavar='file', required=False,
-                            help='system dictionary (default: linked system_dic, see link -h)')
+                            help='system dictionary (default: core dic)')
     parser_ubd.add_argument("in_files", metavar="file", nargs=argparse.ONE_OR_MORE,
                             help='source files with CSV format (one or more)')
     parser_ubd.set_defaults(handler=_command_user_build, print_usage=parser_ubd.print_usage)

--- a/sudachipy/config.py
+++ b/sudachipy/config.py
@@ -14,7 +14,9 @@
 
 import json
 import os
+import warnings
 from importlib import import_module
+from importlib.util import find_spec
 from pathlib import Path
 from typing import List
 
@@ -24,69 +26,69 @@ DEFAULT_RESOURCEDIR = DEFAULT_RESOURCEDIR.as_posix()
 DEFAULT_SETTINGFILE = DEFAULT_SETTINGFILE.as_posix()
 
 
-def unlink_default_dict_package(output, verbose=True):
-    try:
-        dst_path = Path(import_module('sudachidict').__file__).parent
-    except ImportError:
-        if verbose:
-            print('Package `sudachidict` does not exist.', file=output)
-        return
-
-    if dst_path.is_symlink():
-        dst_path.unlink()
-        if verbose:
-            print('Removed the package symbolic link `sudachidict`.', file=output)
-    if dst_path.exists():
-        raise IOError('Unlink failed (The `sudachidict` directory exists and it is not a symbolic link).')
+def get_absolute_dict_path(dict_type: str) -> str:
+    pkg_path = Path(import_module('sudachidict_' + dict_type).__file__).parent
+    dic_path = pkg_path / 'resources' / 'system.dic'
+    return str(dic_path.absolute())
 
 
-def set_default_dict_package(dict_package, output):
-    unlink_default_dict_package(output, verbose=False)
-
-    src_path = Path(import_module(dict_package).__file__).parent
-    dst_path = src_path.parent / 'sudachidict'
-    dst_path.symlink_to(src_path)
-    print('Set the default dictionary to `{}`.'.format(dict_package), file=output)
-
-    return dst_path
+def to_absolute_resource_path(resource_dir: str, dict_path: str) -> str:
+    if Path(dict_path).is_absolute():
+        return dict_path
+    else:
+        return os.path.join(resource_dir, dict_path)
 
 
-def create_default_link_for_sudachidict_core(output):
-    try:
-        dict_path = Path(import_module('sudachidict').__file__).parent
-    except ImportError:
-        try:
-            import_module('sudachidict_core')
-        except ImportError:
-            raise KeyError('You need to specify `systemDict` in the config when `sudachidict_core` is not installed.')
-        try:
-            import_module('sudachidict_full')
-            raise KeyError('Multiple dictionaries installed. Set the default with `link -t` command.')
-        except ImportError:
-            pass
-        try:
-            import_module('sudachidict_small')
-            raise KeyError('Multiple dictionaries installed. Set the default with `link -t` command.')
-        except ImportError:
-            pass
-        dict_path = set_default_dict_package('sudachidict_core', output=output)
-    return str(dict_path / 'resources' / 'system.dic')
+def find_dict_path(dict_type='core'):
+    is_installed = find_spec('sudachidict_{}'.format(dict_type))
+    if is_installed:
+        return get_absolute_dict_path(dict_type)
+    else:
+        raise ModuleNotFoundError(
+            'Package `sudachidict_{}` dose not exist. '
+            'You may install it with a command `$ pip install sudachidict_{}`'.format(dict_type, dict_type)
+        )
 
 
 class _Settings(object):
 
+    DICT_PATH_KEY = 'systemDict'
+    CHAR_DEF_KEY = 'characterDefinitionFile'
+    USER_DICT_PATH_KEY = 'userDict'
+
     def __init__(self):
         self.__is_active = False
         self.__dict_ = None
+        self.__config_path = None
         self.resource_dir = None
 
-    def set_up(self, path=None, resource_dir=None) -> None:
-        path = path or DEFAULT_SETTINGFILE
-        resource_dir = resource_dir or os.path.dirname(path)
-        with open(path, 'r', encoding='utf-8') as f:
+    def set_up(self, config_path=None, resource_dir=None, dict_type=None) -> None:
+        config_path = config_path or DEFAULT_SETTINGFILE
+        self.__config_path = config_path
+        resource_dir = resource_dir or os.path.dirname(config_path)
+        with open(config_path, 'r', encoding='utf-8') as f:
             self.__dict_ = json.load(f)
         self.__is_active = True
         self.resource_dir = resource_dir
+        if dict_type is not None:
+            if dict_type in ['small', 'core', 'full']:
+                if self.DICT_PATH_KEY in self.__dict_ and self.__dict_[self.DICT_PATH_KEY] and \
+                        'sudachidict_{}'.format(dict_type) not in self.__dict_[self.DICT_PATH_KEY]:
+                    warnings.warn(
+                        'Two system dictionaries may be specified. '
+                        'The `sudachidict_{}` defined "dict_type" overrides those defined in the config file.'.format(dict_type)
+                    )
+                self.__dict_[self.DICT_PATH_KEY] = find_dict_path(dict_type=dict_type)
+            else:
+                raise ValueError('"dict_type" must be "small", "core", or "full".')
+        else:
+            if self.DICT_PATH_KEY not in self.__dict_ or not self.__dict_[self.DICT_PATH_KEY]:
+                self.__dict_[self.DICT_PATH_KEY] = find_dict_path()
+
+    def __setitem__(self, key, value):
+        if not self.__is_active:
+            self.set_up()
+        self.__dict_[key] = value
 
     def __getitem__(self, key):
         if not self.__is_active:
@@ -100,24 +102,19 @@ class _Settings(object):
         return item in self.__dict_.keys()
 
     def system_dict_path(self) -> str:
-        key = 'systemDict'
-        if key in self.__dict_:
-            return os.path.join(self.resource_dir, self.__dict_[key])
-        with open(os.devnull, 'w') as f:
-            dict_path = create_default_link_for_sudachidict_core(output=f)
-        self.__dict_[key] = dict_path
-        return dict_path
+        dict_path = self.__dict_[self.DICT_PATH_KEY]
+        return to_absolute_resource_path(self.resource_dir, dict_path)
 
     def char_def_path(self) -> str:
-        key = 'characterDefinitionFile'
+        key = self.CHAR_DEF_KEY
         if key in self.__dict_:
-            return os.path.join(self.resource_dir, self.__dict_[key])
+            return to_absolute_resource_path(self.resource_dir, self.__dict_[key])
         raise KeyError('`{}` not defined in setting file'.format(key))
 
     def user_dict_paths(self) -> List[str]:
-        key = 'userDict'
+        key = self.USER_DICT_PATH_KEY
         if key in self.__dict_:
-            return [os.path.join(self.resource_dir, path) for path in self.__dict_[key]]
+            return [to_absolute_resource_path(self.resource_dir, path) for path in self.__dict_[key]]
         return []
 
 

--- a/sudachipy/dictionary.py
+++ b/sudachipy/dictionary.py
@@ -22,10 +22,14 @@ from .plugin.path_rewrite import get_path_rewrite_plugins
 from .tokenizer import Tokenizer
 
 
+class UndefinedDictionaryError(Exception):
+    pass
+
+
 class Dictionary:
 
-    def __init__(self, config_path=None, resource_dir=None):
-        config.settings.set_up(config_path, resource_dir)
+    def __init__(self, config_path=None, resource_dir=None, dict_type=None):
+        config.settings.set_up(config_path, resource_dir, dict_type)
         self.grammar = None
         self.lexicon = None
         self.input_text_plugins = []
@@ -62,7 +66,7 @@ class Dictionary:
 
     def _read_system_dictionary(self, filename):
         if filename is None:
-            raise AttributeError("system dictionary is not specified")
+            raise ValueError("system dictionary is not specified")
         dict_ = BinaryDictionary.from_system_dictionary(filename)
         self.dictionaries.append(dict_)
         self.grammar = dict_.grammar

--- a/sudachipy/resources/sudachi.json
+++ b/sudachipy/resources/sudachi.json
@@ -1,4 +1,5 @@
 {
+    "systemDict" : "",
     "characterDefinitionFile" : "char.def",
     "inputTextPlugin" : [
         { "class" : "sudachipy.plugin.input_text.DefaultInputTextPlugin" },

--- a/tests/test_switchdictionary.py
+++ b/tests/test_switchdictionary.py
@@ -1,0 +1,102 @@
+import json
+import os
+import shutil
+import tempfile
+import time
+from logging import getLogger
+from unittest import TestCase
+
+from sudachipy.dictionary import Dictionary
+from sudachipy.dictionarylib import SYSTEM_DICT_VERSION_2
+from sudachipy.dictionarylib.dictionarybuilder import DictionaryBuilder
+from sudachipy.dictionarylib.dictionaryheader import DictionaryHeader
+
+
+class TestSwitchDictionary(TestCase):
+
+    def setUp(self):
+        self.logger = getLogger()
+        self.logger.disabled = True
+
+        self.temp_dir = tempfile.mkdtemp()
+        self.resource_dir = os.path.join(self.temp_dir, 'resources')
+        os.makedirs(self.resource_dir)
+
+        test_resource_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources')
+        self.char_def_path = os.path.join(self.resource_dir, 'char.def')
+        shutil.copy(os.path.join(test_resource_dir, 'char.def'), self.char_def_path)
+
+        self.sudachi_json_path = os.path.join(self.resource_dir, 'sudachi.json')
+        shutil.copy(os.path.join(test_resource_dir, 'sudachi.json'), self.sudachi_json_path)
+        self._rewrite_json(self.sudachi_json_path, 'userDict', [])
+
+        self.matrix_path = os.path.join(self.resource_dir, 'matrix.txt')
+        with open(self.matrix_path, 'w', encoding='utf-8') as wf:
+            wf.write('1 1\n0 0 200\n')
+
+        small_lexs = ["島,0,0,0,島,名詞,普通名詞,一般,*,*,*,シマ,島,*,A,*,*,*"]
+        core_lexs = ["徳島本町,0,0,0,徳島本町,名詞,固有名詞,地名,一般,*,*,トクシマホンチョウ,徳島本町,*,A,*,*,*,*"]
+        notcore_lexs = ["徳島堰,0,0,0,徳島堰,名詞,固有名詞,一般,*,*,*,トクシマセギ,徳島堰,*,A,*,*,*"]
+
+        small_lines = small_lexs
+        core_lines = small_lexs + core_lexs
+        full_lines = small_lexs + core_lexs + notcore_lexs
+
+        self.small_txt_path = os.path.join(self.resource_dir, 'small.csv')
+        self.core_txt_path = os.path.join(self.resource_dir, 'core.csv')
+        self.full_txt_path = os.path.join(self.resource_dir, 'full.csv')
+
+        self.small_dic_path = self._build_dictionary(self.small_txt_path, small_lines, 'small.dic')
+        self.core_dic_path = self._build_dictionary(self.core_txt_path, core_lines, 'core.dic')
+        self.full_dic_path = self._build_dictionary(self.full_txt_path, full_lines, 'full.dic')
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    @staticmethod
+    def _rewrite_json(json_file_path, k, v):
+        with open(json_file_path, 'r') as f:
+            obj = json.load(f)
+        obj[k] = v
+        with open(json_file_path, 'w') as f:
+            json.dump(obj, f, ensure_ascii=False, indent=4)
+
+    def _build_dictionary(self, input_txt_path, lex_lines, dictionary_name):
+        with open(input_txt_path, 'w', encoding='utf-8') as wf:
+            wf.write("\n".join(lex_lines))
+
+        out_path = os.path.join(self.resource_dir, dictionary_name)
+        out_stream = open(out_path, 'wb')
+        lexicon_paths = [input_txt_path]
+        matrix_input_stream = open(self.matrix_path, 'r', encoding='utf-8')
+
+        header = DictionaryHeader(SYSTEM_DICT_VERSION_2, int(time.time()), 'test')
+        out_stream.write(header.to_bytes())
+        builder = DictionaryBuilder(logger=self.logger)
+        builder.build(lexicon_paths, matrix_input_stream, out_stream)
+        out_stream.close()
+        matrix_input_stream.close()
+
+        return out_path
+
+    def test_switch_dictionary(self):
+        self._rewrite_json(self.sudachi_json_path, 'systemDict', 'small.dic')  # relative path
+        self.dict = Dictionary(config_path=self.sudachi_json_path, resource_dir=self.resource_dir)
+        self.assertEqual(1, self.dict.lexicon.size())
+        self._rewrite_json(self.sudachi_json_path, 'systemDict', self.small_dic_path)  # abstract path
+        self.dict = Dictionary(config_path=self.sudachi_json_path, resource_dir=self.resource_dir)
+        self.assertEqual(1, self.dict.lexicon.size())
+
+        self._rewrite_json(self.sudachi_json_path, 'systemDict', 'core.dic')
+        self.dict = Dictionary(config_path=self.sudachi_json_path, resource_dir=self.resource_dir)
+        self.assertEqual(2, self.dict.lexicon.size())
+        self._rewrite_json(self.sudachi_json_path, 'systemDict', self.core_dic_path)
+        self.dict = Dictionary(config_path=self.sudachi_json_path, resource_dir=self.resource_dir)
+        self.assertEqual(2, self.dict.lexicon.size())
+
+        self._rewrite_json(self.sudachi_json_path, 'systemDict', 'full.dic')
+        self.dict = Dictionary(config_path=self.sudachi_json_path, resource_dir=self.resource_dir)
+        self.assertEqual(3, self.dict.lexicon.size())
+        self._rewrite_json(self.sudachi_json_path, 'systemDict', self.full_dic_path)
+        self.dict = Dictionary(config_path=self.sudachi_json_path, resource_dir=self.resource_dir)
+        self.assertEqual(3, self.dict.lexicon.size())


### PR DESCRIPTION
Related: #148  #138  #107 #100 

I have changed the function of how system dictionaries are specified in SudachiPy.

* Add `Dictionary()` argument `dict_type` to specify a dictionary from a command line or program.
* Removed `link` command to specify a dictionary using symbolic link.

