### PR TITLE
fix line number for error log

### DIFF
--- a/sudachipy/dictionarylib/dictionarybuilder.py
+++ b/sudachipy/dictionarylib/dictionarybuilder.py
@@ -91,7 +91,7 @@ class DictionaryBuilder(object):
         line_no = -1
         try:
             for i, row in enumerate(csv.reader(lexicon_input_stream)):
-                line_no = -1
+                line_no = i
                 entry = self.parse_line(row)
                 if entry.headword:
                     self.add_to_trie(entry.headword, len(self.entries))

--- a/sudachipy/dictionarylib/dictionarybuilder.py
+++ b/sudachipy/dictionarylib/dictionarybuilder.py
@@ -97,7 +97,7 @@ class DictionaryBuilder(object):
                     self.add_to_trie(entry.headword, len(self.entries))
                 self.entries.append(entry)
         except Exception as e:
-            if line_no > 0:
+            if line_no >= 0:
                 self.logger.error(
                     '{} at line {} in {}\n'.format(e.args[0], line_no, lexicon_input_stream.name))
             raise e


### PR DESCRIPTION
I found a small bug and would like to report it. Line numbers are not logged correctly when user dictionary has invalid CSV format.

This is my first PR, so if you have any problems, please let me know.