### PR TITLE
Raise ValueError when word defined in user dict is not found in system dict

### DIFF
--- a/sudachipy/dictionarylib/dictionarybuilder.py
+++ b/sudachipy/dictionarylib/dictionarybuilder.py
@@ -329,7 +329,7 @@ class DictionaryBuilder(object):
             else:
                 ids.append(self.word_to_id(word))
                 if ids[-1] < 0:
-                    raise ValueError('not found such a word: {word}')
+                    raise ValueError('not found such a word: {}'.format(word))
         return ids
 
     @staticmethod

--- a/sudachipy/dictionarylib/dictionarybuilder.py
+++ b/sudachipy/dictionarylib/dictionarybuilder.py
@@ -329,7 +329,7 @@ class DictionaryBuilder(object):
             else:
                 ids.append(self.word_to_id(word))
                 if ids[-1] < 0:
-                    return ValueError('not found such a word')
+                    raise ValueError('not found such a word: {word}')
         return ids
 
     @staticmethod


### PR DESCRIPTION
I got an ambiguous error message when word defined in user dict is not found in system dict while ubuild subcommand exec. 

```sh
TypeError: object of type 'ValueError' has no len()
```

Upon investigation, I found that TypeError was occurring because "発作性" is not found in core dict. So I changed it to raise ValueError with detail message that makes it easier to debug when a ValueError occurs during ubuild subcommand.

Below is a command that reproduces this problem.
```sh
$ echo 発作性心房細動,4786,4786,5000,発作性心房細動,名詞,普通名詞,一般,*,*,*,,発作性心房細動,*,C,"発作,名詞,普通名詞,一般,*,*,*,ホッサ/性,接尾辞,名詞的,一般,*,*,*,セイ/心房,名詞,普通名詞,一般,*,*,*,シンボウ/細動,名詞,普通名詞,一般,*,*,*,サイドウ","発作性,名詞,普通名詞,一般,*,*,*,ホッサセイ/心房,名詞,普通名詞,一般,*,*,*,シンボウ/細動,名詞,普通名詞,一般,*,*,*,サイドウ",* > sudachi_user_dict.txt

$ sudachipy ubuild sudachi_user_dict.txt -o sudachi_user.dic

reading the source file...2 words
writing the POS table...2 bytes
writing the connection matrix...4 bytes
building the trie...done
writing the trie...1028 bytes
writing the word-ID table...14 bytes
writing the word parameters...16 bytes
writing the word_infos...Traceback (most recent call last):
  File "/---/.venv/bin/sudachipy", line 8, in <module>
    sys.exit(main())
  File "/---/.venv/lib/python3.9/site-packages/sudachipy/command_line.py", line 220, in main
    args.handler(args, args.print_usage)
  File "/---/.venv/lib/python3.9/site-packages/sudachipy/command_line.py", line 114, in _command_user_build
    builder.build(args.in_files, None, wf)
  File "/---/.venv/lib/python3.9/site-packages/sudachipy/dictionarylib/userdictionarybuilder.py", line 40, in build
    self.write_lexicon(out_stream)
  File "/---/.venv/lib/python3.9/site-packages/sudachipy/dictionarylib/dictionarybuilder.py", line 268, in write_lexicon
    self.write_wordinfo(io_out)
  File "/---/.venv/lib/python3.9/site-packages/sudachipy/dictionarylib/dictionarybuilder.py", line 293, in write_wordinfo
    self.write_intarray(self.parse_splitinfo(entry.bunit_split_string))
  File "/---/.venv/lib/python3.9/site-packages/sudachipy/dictionarylib/dictionarybuilder.py", line 399, in write_intarray
    self.byte_buffer.write_int(len(array), 'byte')
TypeError: object of type 'ValueError' has no len()
```
