### PR TITLE
Exactly match the dict split info id

### DIFF
--- a/sudachipy/dictionarylib/dictionarybuilder.py
+++ b/sudachipy/dictionarylib/dictionarybuilder.py
@@ -334,7 +334,7 @@ class DictionaryBuilder(object):
 
     @staticmethod
     def __is_id(text):
-        return re.match(r'U?\d+', text)
+        return re.match(r'U?\d+$', text)
 
     def parse_id(self, text):
         if text.startswith('U'):


### PR DESCRIPTION
Fixes #155 

e.g,

```
In [1]: import re

In [2]: text = "1,名詞,数詞,*,*,*,*,イチ"

In [3]: re.match(r'U?\d+', text)
Out[3]: <re.Match object; span=(0, 1), match='1'>

In [4]: re.match(r'U?\d+$', text)
```