### PR TITLE
fix: slow ubuild with word info split

### DIFF
--- a/sudachipy/dictionarylib/doublearraylexicon.py
+++ b/sudachipy/dictionarylib/doublearraylexicon.py
@@ -78,7 +78,7 @@ class DoubleArrayLexicon(Lexicon):
         return self.word_params.size
 
     def get_word_id(self, headword: str, pos_id: int, reading_form: str) -> int:
-        for wid in range(self.word_infos.size()):
+        for wid, _ in self.lookup(headword.encode('utf-8'), 0):
             info = self.word_infos.get_word_info(wid)
             if info.surface == headword \
                     and info.pos_id == pos_id \

--- a/sudachipy/dictionarylib/doublearraylexicon.py
+++ b/sudachipy/dictionarylib/doublearraylexicon.py
@@ -79,12 +79,20 @@ class DoubleArrayLexicon(Lexicon):
 
     def get_word_id(self, headword: str, pos_id: int, reading_form: str) -> int:
         for wid, _ in self.lookup(headword.encode('utf-8'), 0):
-            info = self.word_infos.get_word_info(wid)
-            if info.surface == headword \
-                    and info.pos_id == pos_id \
-                    and info.reading_form == reading_form:
+            if self._compare_word_id(wid, headword, pos_id, reading_form):
                 return wid
+
+        for wid in range(self.word_infos.size()):
+            if self._compare_word_id(wid, headword, pos_id, reading_form):
+                return wid
+
         return -1
+
+    def _compare_word_id(self, wid: int, headword: str, pos_id: int, reading_form: str) -> bool:
+        info = self.word_infos.get_word_info(wid)
+        return info.surface == headword \
+            and info.pos_id == pos_id \
+            and info.reading_form == reading_form
 
     def get_dictionary_id(self, word_id: int) -> int:
         return 0


### PR DESCRIPTION
fix #157 

Now it's 1 second to build a record, or even 100 records as well. This is same speed as building with word id split info. 

```
$ sudachipy ubuild user.csv -o user.dic
reading the source file...1 words
writing the POS table...2 bytes
writing the connection matrix...4 bytes
building the trie...done
writing the trie...1028 bytes
writing the word-ID table...9 bytes
writing the word parameters...10 bytes
writing the word_infos...70 bytes
writing word_info offsets...4 bytes

real	0m0.935s
user	0m0.801s
sys	0m0.144s
```

user.csv:

```csv
舞台藝術,5146,5146,8000,舞台藝術,名詞,普通名詞,一般,*,*,*,ブタイゲイジュツ,舞台芸術,*,C,"舞台,名詞,普通名詞,一般,*,*,*,ブタイ/藝術,名詞,普通名詞,一般,*,*,*,ゲイジュツ","舞台,名詞,普通名詞,一般,*,*,*,ブタイ/藝術,名詞,普通名詞,一般,*,*,*,ゲイジュツ","舞台,名詞,普通名詞,一般,*,*,*,ブタイ/藝術,名詞,普通名詞,一般,*,*,*,ゲイジュツ",*
```
