### PR TITLE
Replace broken build badge with working one

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,7 +1,7 @@
 # 日本語形態素解析器 SudachiPy チュートリアル
 [![PyPi version](https://img.shields.io/pypi/v/sudachipy.svg)](https://pypi.python.org/pypi/sudachipy/)
 [![](https://img.shields.io/badge/python-3.5+-blue.svg)](https://www.python.org/downloads/release/python-350/)
-[![Build Status](https://travis-ci.com/WorksApplications/SudachiPy.svg?branch=develop)](https://travis-ci.com/WorksApplications/SudachiPy)
+[![build](https://github.com/WorksApplications/SudachiPy/actions/workflows/build.yml/badge.svg)](https://github.com/WorksApplications/SudachiPy/actions/workflows/build.yml)
 [![](https://img.shields.io/github/license/WorksApplications/SudachiPy.svg)](https://github.com/WorksApplications/SudachiPy/blob/develop/LICENSE)
 
 SudachiPyは日本語形態素解析器[Sudachi](https://github.com/WorksApplications/Sudachi)のpython版です。


### PR DESCRIPTION
This repo does not use Travis CI at this moment, then better to remove its build status badge from README.
Instead, we will have another badge provided by GitHub Actions.